### PR TITLE
Add Package-Requires header

### DIFF
--- a/term+mux.el
+++ b/term+mux.el
@@ -4,6 +4,7 @@
 ;; URL: http://github.com/tarao/term+-el
 ;; Version: 0.1
 ;; Keywords: terminal, emulation
+;; Package-Requires: ((term+ "0.1") (tab-group "0.1"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
For the following MELPA registration, we need to add a `Package-Requires` header to `term+mux.el`.

https://github.com/milkypostman/melpa/pull/1469
