### PR TITLE
Update url of tab-group-el submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/tab-group-el"]
 	path = lib/tab-group-el
-	url = git://github.com/tarao/tab-group-el.git
+	url = https://github.com/tarao/tab-group-el.git


### PR DESCRIPTION
Github no longer supports git:// urls.

This prevents the package from being build on Melpa because currently the tool used to do so (`package-build.el`) insists on checking out all submodules, which here fails.